### PR TITLE
Make cookbook category configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,10 @@ export NO_PROMPT=""
 rake release!
 ```
 
+Optional environment variables:
+
+```
+export COOKBOOK_CATEGORY="Other" # defaults to Other
+```
+
 Note: this setup is intended to be used in a CI system such as jenkins or travis.

--- a/lib/cookbook-release.rb
+++ b/lib/cookbook-release.rb
@@ -19,7 +19,8 @@ module CookbookRelease
         desc "Prepare cookbook release and push tag to git"
         task "release!" do
           opts = {
-            no_prompt: ENV['NO_PROMPT']
+            no_prompt: ENV['NO_PROMPT'],
+            category: ENV['COOKBOOK_CATEGORY'],
           }
           git = GitUtilities.new
           Release.new(git, opts).release!

--- a/lib/cookbook-release/release.rb
+++ b/lib/cookbook-release/release.rb
@@ -18,6 +18,7 @@ class Release
     @git         = git
     @no_prompt   = opts[:no_prompt]
     @git.no_prompt = @no_prompt
+    @category    = opts[:category] || 'Other'
   end
 
   def last_release
@@ -83,10 +84,11 @@ class Release
       exit 1 unless agreed
       git.push_tag(new_version)
       supermarket = Supermarket.new
-      supermarket.publish_ck('Others')
-    ensure
+      supermarket.publish_ck(@category)
+    rescue
       puts HighLine.color("Release aborted, you have to reset to previous state manually", :red)
       puts ":use with care: #{git.reset_command(new_version)}"
+      raise
     end
   end
 end

--- a/spec/release_spec.rb
+++ b/spec/release_spec.rb
@@ -19,6 +19,32 @@ describe Release do
     end
   end
 
+  describe '.release!' do
+    it 'calls category with a valid default category' do
+
+      c = double('c',
+                 :major? => true,
+                 :[]     => '',
+                 :color  => :red,
+                )
+      git = double('git',
+                   :clean_index! => true,
+                   :compute_last_release => '1.0.0'.to_version,
+                   :compute_changelog => [c],
+                   :tag => true,
+                   :push_tag => true,
+                  )
+      allow(git).to receive(:no_prompt=)
+      release = Release.new(git, no_prompt: true)
+
+      supermarket = double('supermarket')
+      expect(Supermarket).to receive(:new).and_return(supermarket)
+
+      expect(supermarket).to receive(:publish_ck).with('Other')
+      release.release!
+    end
+  end
+
 
   describe '.new_version' do
 


### PR DESCRIPTION
- correct typo in default category
- allow to configure cookbook category through environment
- also fixed a bug where the error message would always be displayed

Fix #5
Fix #4 

cc @aboten