### PR TITLE
Launch git command in the proper git repository

### DIFF
--- a/lib/cookbook-release/git-utilities.rb
+++ b/lib/cookbook-release/git-utilities.rb
@@ -8,7 +8,10 @@ class GitUtilities
   attr_accessor :no_prompt
 
   def initialize(options={})
-    @tag_prefix = options['tag_prefix'] || ''
+    @tag_prefix = options[:tag_prefix] || ''
+    @shellout_opts = {
+      cwd: options[:cwd]
+    }
   end
 
   def reset_command(new_version)
@@ -16,9 +19,9 @@ class GitUtilities
   end
 
   def clean_index?
-    clean_index = Mixlib::ShellOut.new("git diff --exit-code")
+    clean_index = Mixlib::ShellOut.new("git diff --exit-code", @shellout_opts)
     clean_index.run_command
-    clean_staged = Mixlib::ShellOut.new("git diff --exit-code --cached")
+    clean_staged = Mixlib::ShellOut.new("git diff --exit-code --cached", @shellout_opts)
     clean_staged.run_command
     !clean_index.error? && !clean_staged.error?
   end
@@ -33,14 +36,14 @@ class GitUtilities
       'git describe',
       "--tags",
       "--match \"#{@tag_prefix}[0-9]\.[0-9]*\.[0-9]*\""
-    ].join " ")
+    ].join(" "), @shellout_opts)
     tag.run_command
     tag.stdout.split('-').first.to_version
   end
 
   def compute_changelog(since)
     # TODO use whole commit message instead of title only
-    log_cmd = Mixlib::ShellOut.new("git log --pretty='format:%an <%ae>::%s::%h' #{since}..HEAD")
+    log_cmd = Mixlib::ShellOut.new("git log --pretty='format:%an <%ae>::%s::%h' #{since}..HEAD", @shellout_opts)
     log_cmd.run_command
     log = log_cmd.stdout
     log.split("\n").map do |entry|
@@ -54,13 +57,13 @@ class GitUtilities
   end
 
   def tag(version)
-    cmd = Mixlib::ShellOut.new("git tag #{@tag_prefix}#{version}")
+    cmd = Mixlib::ShellOut.new("git tag #{@tag_prefix}#{version}", @shellout_opts)
     cmd.run_command
     cmd.error!
   end
 
   def choose_remote
-    cmd = Mixlib::ShellOut.new("git remote")
+    cmd = Mixlib::ShellOut.new("git remote", @shellout_opts)
     cmd.run_command
     cmd.error!
     remotes = cmd.stdout.split("\n")
@@ -74,7 +77,7 @@ class GitUtilities
 
   def push_tag(version)
     remote = choose_remote
-    cmd = Mixlib::ShellOut.new("git push #{remote} #{@tag_prefix}#{version}")
+    cmd = Mixlib::ShellOut.new("git push #{remote} #{@tag_prefix}#{version}", @shellout_opts)
     cmd.run_command
     cmd.error!
   end

--- a/lib/cookbook-release/release.rb
+++ b/lib/cookbook-release/release.rb
@@ -1,7 +1,8 @@
 class Release
 
-  def self.current_version
-    r = Release.new(GitUtilities.new)
+  # file will be used to determine the git directory
+  def self.current_version(file)
+    r = Release.new(GitUtilities.new(cwd: File.dirname(file)))
     begin
       r.new_version.first
     rescue ExistingRelease


### PR DESCRIPTION
Otherwise, version detection might not work properly when the :path
source type in berkshelf.

Fix #7

cc @aboten