### PR TITLE
Fix some release! task bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ export SUPERMARKET_CLIENTKEYFILE=/tmp/my_key.pem
 export SUPERMARKET_USERID=my_username
 export SUPERMARKET_URL="http://supermarket.chef.io/api/v1/cookbooks"
 export NO_PROMPT=""
+export SUPERMARKET_NO_SSL_VERIFY=1
 rake release!
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Include cookbook-release into your `Gemfile`.
 Require cookbook-release into the `metadata.rb` file and replace the version by the helper:
 
 ```
-version          Release.current_version
+require 'cookbook-release'
+version          Release.current_version(__FILE__)
 ```
 
 Include the rake tasks in your Rakefile:

--- a/lib/cookbook-release/git-utilities.rb
+++ b/lib/cookbook-release/git-utilities.rb
@@ -14,6 +14,10 @@ class GitUtilities
     }
   end
 
+  def self.git?(dir)
+    !Mixlib::ShellOut.new('git status', cwd: dir).run_command.error?
+  end
+
   def reset_command(new_version)
     "git reset --hard HEAD^ && git tag -d #{new_version}"
   end

--- a/lib/cookbook-release/release.rb
+++ b/lib/cookbook-release/release.rb
@@ -2,12 +2,17 @@ class Release
 
   # file will be used to determine the git directory
   def self.current_version(file)
-    r = Release.new(GitUtilities.new(cwd: File.dirname(file)))
+    dir = File.dirname(file)
+    version_file = File.join(dir, '.cookbook_version')
+
+    return File.read(version_file) if !GitUtilities.git?(dir) && File.exist?(version_file)
+
+    r = Release.new(GitUtilities.new(cwd: dir))
     begin
       r.new_version.first
     rescue ExistingRelease
       r.last_release
-    end
+    end.tap { |v| File.write(version_file, v) }
   end
 
   class ExistingRelease < StandardError

--- a/lib/cookbook-release/supermarket.rb
+++ b/lib/cookbook-release/supermarket.rb
@@ -14,6 +14,7 @@ class Supermarket
     @url        = opts[:url] || ENV['SUPERMARKET_URL'] || (raise "Require a supermarket url")
     @user_id    = opts[:user_id] || ENV['SUPERMARKET_USERID'] || (raise "Require a user id")
     @client_key = opts[:client_key_file] || ENV['SUPERMARKET_CLIENTKEYFILE'] || (raise "Require a client key file")
+    Chef::Config[:ssl_verify_mode] = :verify_none if ENV['SUPERMARKET_NO_SSL_VERIFY']
   end
 
   include ::Chef::Mixin::ShellOut


### PR DESCRIPTION
Fix #6 by adding environment variable to control ssl certificate validation on cookbook release.
Fix `missing to_version method` exception on `release!` task by setting up a local file with the latest version.
Fix & complete README.