### PR TITLE
Make a simpler heuristic to detect if we are in a git directory

### DIFF
--- a/lib/cookbook-release/git-utilities.rb
+++ b/lib/cookbook-release/git-utilities.rb
@@ -16,11 +16,7 @@ module CookbookRelease
     end
 
     def self.git?(dir)
-      !Mixlib::ShellOut.new(
-        'git status',
-        cwd: dir,
-        environment: { GIT_DIR: dir }
-      ).run_command.error?
+      File.directory?(::File.join(dir, '.git'))
     end
 
     def reset_command(new_version)


### PR DESCRIPTION
We don't want to check that we are in a git directory but (more strict)
that the cookbook dir is a independant repository.

Simply testing for .git/ existence seems sufficient