### PR TITLE
Add ability to publish a html changelog from git history

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Examples of messages:
 - Fix migration code for old centos versions
 
 
-One-time setup
+One-time setup (for cookbooks)
 -----
 
 Include cookbook-release into your `Gemfile`.
@@ -65,3 +65,15 @@ export COOKBOOK_CATEGORY="Other" # defaults to Other
 ```
 
 Note: this setup is intended to be used in a CI system such as jenkins or travis.
+
+
+Changelog generation for chef-repositories
+----
+
+Using:
+```
+require 'cookbook-release'
+CookbookRelease::Rake::RepoTask.new
+```
+
+will allow to create tasks to generate html changelog between HEAD and master branch. It aims to make some changes more visible such as [Risky] tag (or any tag used for major changes).

--- a/cookbook-release.gemspec
+++ b/cookbook-release.gemspec
@@ -6,7 +6,7 @@ require 'English'
 
 Gem::Specification.new do |spec|
   spec.name          = 'cookbook-release'
-  spec.version       = '1.0.1'
+  spec.version       = '1.1.0'
   spec.authors       = ['Grégoire Seux']
   spec.email         = 'g.seux@criteo.com'
   spec.summary       = 'Provide primitives (and rake tasks) to release a cookbook'

--- a/lib/cookbook-release.rb
+++ b/lib/cookbook-release.rb
@@ -11,21 +11,21 @@ module CookbookRelease
   module Rake
 
     class RepoTask < ::Rake::TaskLib
-      def initialize
-        define_tasks
-      end
-
-      def define_tasks
+      def initialize(opts = {}, &html_block)
         desc "Display raw changelog between branches"
         task "changelog:raw" do
           git = GitUtilities.new
-          puts Changelog.new(git).raw
+          puts Changelog.new(git, opts).raw
         end
 
         desc "Display html changelog between branches"
         task "changelog:html" do
           git = GitUtilities.new
-          puts Changelog.new(git).html
+          html = Changelog.new(git, opts).html
+          if block_given?
+            html = html_block.call(html)
+          end
+          puts html
         end
       end
     end

--- a/lib/cookbook-release.rb
+++ b/lib/cookbook-release.rb
@@ -2,12 +2,34 @@ require_relative 'cookbook-release/commit'
 require_relative 'cookbook-release/git-utilities'
 require_relative 'cookbook-release/supermarket'
 require_relative 'cookbook-release/release'
+require_relative 'cookbook-release/changelog'
 
 require 'rake'
 require 'rake/tasklib'
 
 module CookbookRelease
   module Rake
+
+    class RepoTask < ::Rake::TaskLib
+      def initialize
+        define_tasks
+      end
+
+      def define_tasks
+        desc "Display raw changelog between branches"
+        task "changelog:raw" do
+          git = GitUtilities.new
+          puts Changelog.new(git).raw
+        end
+
+        desc "Display html changelog between branches"
+        task "changelog:html" do
+          git = GitUtilities.new
+          puts Changelog.new(git).html
+        end
+      end
+    end
+
     class CookbookTask < ::Rake::TaskLib
 
       def initialize(namespaced=false)

--- a/lib/cookbook-release/changelog.rb
+++ b/lib/cookbook-release/changelog.rb
@@ -1,7 +1,14 @@
 module CookbookRelease
   class Changelog
-    def initialize(git)
+
+    DEFAULT_OPTS = {
+      expand_major: true,
+      expand_risky: true,
+    }
+
+    def initialize(git, opts = {})
       @git = git
+      @opts = DEFAULT_OPTS.merge(opts)
     end
 
     def raw
@@ -15,7 +22,9 @@ module CookbookRelease
   <body>
       EOH
       result << changelog.map do |c|
-        full_body = c.risky? || c.major?
+        full_body ||= @opts[:expand_major] && c.major?
+        full_body ||= @opts[:expand_risky] && c.risky?
+        full_body ||= @opts[:expand_commit] && (c[:subject] =~ @opts[:expand_commit] || c[:body] =~ @opts[:expand_commit])
         c.to_s_html(full_body)
       end.map { |c| "    <p>#{c}</p>" }
       result <<  <<-EOH

--- a/lib/cookbook-release/changelog.rb
+++ b/lib/cookbook-release/changelog.rb
@@ -1,0 +1,32 @@
+module CookbookRelease
+  class Changelog
+    def initialize(git)
+      @git = git
+    end
+
+    def raw
+      changelog.map(&:to_s_oneline)
+    end
+
+    def html
+      result = []
+      result << <<-EOH
+<html>
+  <body>
+      EOH
+      result << changelog.map(&:to_s_html).map { |c| "    <p>#{c}</p>" }
+      result <<  <<-EOH
+  </body>
+</html>
+      EOH
+      result.join("\n")
+    end
+
+    private
+
+    def changelog
+      @git.compute_changelog('master')
+    end
+
+  end
+end

--- a/lib/cookbook-release/changelog.rb
+++ b/lib/cookbook-release/changelog.rb
@@ -14,7 +14,10 @@ module CookbookRelease
 <html>
   <body>
       EOH
-      result << changelog.map(&:to_s_html).map { |c| "    <p>#{c}</p>" }
+      result << changelog.map do |c|
+        full_body = c.risky? || c.major?
+        c.to_s_html(full_body)
+      end.map { |c| "    <p>#{c}</p>" }
       result <<  <<-EOH
   </body>
 </html>

--- a/lib/cookbook-release/commit.rb
+++ b/lib/cookbook-release/commit.rb
@@ -30,13 +30,31 @@ module CookbookRelease
       !(major? || patch?)
     end
 
+    def risky?
+      !!(self[:subject] =~ /\[risky\]/i)
+    end
+
     def color
       case true
       when major?
         :red
+      when risky?
+        :red
       else
         :grey
       end
+    end
+
+    def to_s_oneline
+      "#{self[:hash]} #{self[:author]} #{self[:subject]}"
+    end
+
+    def to_s_html
+      <<-EOH
+<font color=#{color.to_s}>
+  #{self[:hash]} #{self[:author]} #{self[:subject]}
+</font>
+      EOH
     end
 
   end

--- a/lib/cookbook-release/commit.rb
+++ b/lib/cookbook-release/commit.rb
@@ -49,12 +49,22 @@ module CookbookRelease
       "#{self[:hash]} #{self[:author]} #{self[:subject]}"
     end
 
-    def to_s_html
-      <<-EOH
+    def to_s_html(full)
+      result = []
+      result << <<-EOH
 <font color=#{color.to_s}>
   #{self[:hash]} #{self[:author]} #{self[:subject]}
 </font>
       EOH
+      if full && self[:body]
+        result << <<-EOH
+<pre>
+#{self[:body]}
+</pre>
+        EOH
+      end
+
+      result.join("\n")
     end
 
   end

--- a/spec/changelog_spec.rb
+++ b/spec/changelog_spec.rb
@@ -1,0 +1,20 @@
+require_relative 'spec_helper'
+
+describe CookbookRelease::Changelog do
+  let(:git) do
+    double('git', :no_prompt= => true)
+  end
+
+  describe '.html' do
+
+    it 'colorize Risky commits in red' do
+      expect(git).to receive(:compute_changelog).and_return([
+        CookbookRelease::Commit.new(hash: '654321', subject: '[Risky] hello', author: 'John Doe'),
+        CookbookRelease::Commit.new(hash: '123456', subject: 'hello', author: 'John Doe'),
+      ])
+      changelog = CookbookRelease::Changelog.new(git)
+      expect(changelog.html).to match(/color=red((?!color=grey).)*Risky/m)
+    end
+  end
+
+end

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -103,7 +103,7 @@ describe CookbookRelease::GitUtilities do
       end
 
       changelog = git.compute_changelog('1.0.0')
-      expect(changelog.size).to be(3)
+      expect(changelog.size).to eq(3)
       expect(changelog.map {|c| c[:subject]}).to contain_exactly('A commit', 'Another commit', 'A third one')
     end
   end


### PR DESCRIPTION
This could be use to generate a changelog and enrich it with the major/risky information.