### PR TITLE
Allow bootstrap of cookbook without any release

### DIFF
--- a/cookbook-release.gemspec
+++ b/cookbook-release.gemspec
@@ -6,7 +6,7 @@ require 'English'
 
 Gem::Specification.new do |spec|
   spec.name          = 'cookbook-release'
-  spec.version       = '1.1.2'
+  spec.version       = '1.1.3'
   spec.authors       = ['Grégoire Seux']
   spec.email         = 'g.seux@criteo.com'
   spec.summary       = 'Provide primitives (and rake tasks) to release a cookbook'

--- a/lib/cookbook-release/git-utilities.rb
+++ b/lib/cookbook-release/git-utilities.rb
@@ -36,15 +36,22 @@ module CookbookRelease
       raise "All changes must be committed!" unless clean_index?
     end
 
-    def compute_last_release
-
+    def _compute_last_release
       tag = Mixlib::ShellOut.new([
         'git describe',
         "--tags",
         "--match \"#{@tag_prefix}[0-9]\.[0-9]*\.[0-9]*\""
       ].join(" "), @shellout_opts)
       tag.run_command
-      last = tag.stdout.split('-').first
+      tag.stdout.split('-').first
+    end
+
+    def has_any_release?
+      !!_compute_last_release
+    end
+
+    def compute_last_release
+      last = _compute_last_release
       unless last
         $stderr.puts "No last release found, defaulting to 0.1.0"
         last = '0.1.0'

--- a/lib/cookbook-release/release.rb
+++ b/lib/cookbook-release/release.rb
@@ -38,6 +38,7 @@ module CookbookRelease
 
     # return the new version and the reasons
     def new_version
+      return ['0.1.0'.to_version, []] unless git.has_any_release?
       %w(major minor patch).each do |level|
         changes = git_changelog.select(&"#{level}?".to_sym)
         return [ last_release.send("#{level}!"), changes ] if changes.size > 0

--- a/spec/release_spec.rb
+++ b/spec/release_spec.rb
@@ -31,6 +31,7 @@ describe Release do
                    :clean_index! => true,
                    :compute_last_release => '1.0.0'.to_version,
                    :compute_changelog => [c],
+                   :has_any_release? => true,
                    :tag => true,
                    :push_tag => true,
                   )
@@ -51,6 +52,7 @@ describe Release do
     it 'raise when no commit has been made since last release' do
       allow(git).to receive(:compute_last_release).and_return('1.0.1'.to_version)
       expect(git).to receive(:compute_changelog).and_return([])
+      expect(git).to receive(:has_any_release?).and_return(true)
 
       release = Release.new(git)
       expect{release.new_version}.to raise_error(Release::ExistingRelease, /no commit since/i)
@@ -59,6 +61,7 @@ describe Release do
     it 'suggests major release when one commit is major' do
       allow(git).to receive(:compute_last_release).and_return('1.0.1'.to_version)
       expect(git).to receive(:compute_changelog).and_return([minor, minor, major, patch])
+      expect(git).to receive(:has_any_release?).and_return(true)
 
       release = Release.new(git)
       new_version, reasons = release.new_version
@@ -69,6 +72,7 @@ describe Release do
     it 'suggests minor release when one commit is minor' do
       allow(git).to receive(:compute_last_release).and_return('1.0.1'.to_version)
       expect(git).to receive(:compute_changelog).and_return([minor, minor, patch, patch])
+      expect(git).to receive(:has_any_release?).and_return(true)
 
       release = Release.new(git)
       new_version, reasons = release.new_version
@@ -79,6 +83,7 @@ describe Release do
     it 'suggests patch release when all commits are patches' do
       allow(git).to receive(:compute_last_release).and_return('1.0.1'.to_version)
       expect(git).to receive(:compute_changelog).and_return([patch, patch, patch])
+      expect(git).to receive(:has_any_release?).and_return(true)
 
       release = Release.new(git)
       new_version, reasons = release.new_version


### PR DESCRIPTION
For cookbook without any release, we start by version 0.1.0

Change-Id: I7f1f28026160af299daec520320190c9709fa62f