### PR TITLE
Handle major release greater than 9

### DIFF
--- a/lib/cookbook-release/git-utilities.rb
+++ b/lib/cookbook-release/git-utilities.rb
@@ -43,7 +43,7 @@ module CookbookRelease
       tag = Mixlib::ShellOut.new([
         'git describe',
         "--tags",
-        "--match \"#{@tag_prefix}[0-9]\.[0-9]*\.[0-9]*\""
+        "--match \"#{@tag_prefix}[0-9]*\.[0-9]*\.[0-9]*\""
       ].join(" "), @shellout_opts)
       tag.run_command
       tag.stdout.split('-').first

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -82,6 +82,17 @@ describe CookbookRelease::GitUtilities do
   end
 
   describe '.compute_last_release' do
+    it 'finds the last release when major version is greater than 9' do
+      cmds = <<-EOH
+git commit --allow-empty -m 'none'
+git tag 1.2.3
+git commit --allow-empty -m 'none'
+git tag 12.34.56
+      EOH
+      cmds.split("\n").each { |cmd| ::Mixlib::ShellOut.new(cmd).run_command.error! }
+      expect(git.compute_last_release).to eq('12.34.56')
+    end
+
     it 'finds the last release' do
       cmds = <<-EOH
       git commit --allow-empty -m 'none'


### PR DESCRIPTION
Former tag matching was limiting major release to 9.

*Cc.* @aboten