### PR TITLE
Add a Slack mention of author on risky commits

### DIFF
--- a/lib/cookbook-release/commit.rb
+++ b/lib/cookbook-release/commit.rb
@@ -68,7 +68,14 @@ module CookbookRelease
     end
 
     def to_s_markdown(full)
-      result = "*#{self[:hash]}* _#{self[:author]} <#{self[:email]}>_ `#{self[:subject]}`"
+      result = "*#{self[:hash]}* "
+      if self[:subject] =~ /risky|breaking/i
+        slack_user = self[:email].split('@')[0]
+        result << "@#{slack_user}"
+      else
+        result << "_#{self[:author]} <#{self[:email]}>_"
+      end
+      result << " `#{self[:subject]}`"
       result << "\n```\n#{self[:body]}\n```" if full && self[:body]
       result
     end

--- a/spec/changelog_spec.rb
+++ b/spec/changelog_spec.rb
@@ -31,8 +31,8 @@ describe CookbookRelease::Changelog do
       changelog = CookbookRelease::Changelog.new(git)
       expect(changelog.markdown).to eq('*123456* _John Doe <j.doe@nobody.com>_ `hello`')
     end
-    it 'expand body' do
-      expect(git).to receive(:compute_changelog).and_return(
+    context 'risky commit' do
+      let(:commit) do
         [
           CookbookRelease::Commit.new(
             hash: '654321',
@@ -41,9 +41,19 @@ describe CookbookRelease::Changelog do
             email: 'j.doe@nobody.com',
             body: 'Some Men Just Want to Watch the World Burn')
         ]
-      )
-      changelog = CookbookRelease::Changelog.new(git, expand_risky: true)
-      expect(changelog.markdown).to include("\n```\nSome Men Just Want")
+      end
+
+      it 'expands the body' do
+        expect(git).to receive(:compute_changelog).and_return(commit)
+        changelog = CookbookRelease::Changelog.new(git, expand_risky: true)
+        expect(changelog.markdown).to include("\n```\nSome Men Just Want")
+      end
+
+      it 'mentions the author' do
+        expect(git).to receive(:compute_changelog).and_return(commit)
+        changelog = CookbookRelease::Changelog.new(git, expand_risky: true)
+        expect(changelog.markdown).to start_with('*654321* @j.doe `[Risky] hello`')
+      end
     end
   end
 end


### PR DESCRIPTION
Normal commits will still look like: *123456* _John Doe <j.doe@nobody.com>_ `hello`

Risky / breaking commits will look like: *654321* @j.doe `[Risky] hello`

Because of limited Markdown option for combining mention and other formatting options, there is a tradeoff on the way the mentioned author will appear.