### PR TITLE
Add rake tasks to print changelog by importance

### DIFF
--- a/lib/cookbook-release.rb
+++ b/lib/cookbook-release.rb
@@ -12,16 +12,32 @@ module CookbookRelease
 
     class RepoTask < ::Rake::TaskLib
       def initialize(opts = {}, &html_block)
-        desc "Display raw changelog between branches"
-        task "changelog:raw" do
+        desc 'Display raw changelog between branches'
+        task 'changelog:raw' do
           git = GitUtilities.new
           puts Changelog.new(git, opts).raw
         end
 
-        desc "Display html changelog between branches"
-        task "changelog:html" do
+        desc 'Display raw changelog between branches with risky commits on top'
+        task 'changelog:raw_priority' do
+          git = GitUtilities.new
+          puts Changelog.new(git, opts).raw_priority
+        end
+
+        desc 'Display html changelog between branches'
+        task 'changelog:html' do
           git = GitUtilities.new
           html = Changelog.new(git, opts).html
+          if block_given?
+            html = html_block.call(html)
+          end
+          puts html
+        end
+
+        desc 'Display html changelog between branches with risky commits on top'
+        task 'changelog:html_priority' do
+          git = GitUtilities.new
+          html = Changelog.new(git, opts).html_priority
           if block_given?
             html = html_block.call(html)
           end
@@ -32,6 +48,12 @@ module CookbookRelease
         task 'changelog:markdown' do
           git = GitUtilities.new
           puts Changelog.new(git, opts).markdown
+        end
+
+        desc 'Display markdown changelog between branches with risky commits on top'
+        task 'changelog:markdown_priority' do
+          git = GitUtilities.new
+          puts Changelog.new(git, opts).markdown_priority
         end
       end
     end
@@ -44,8 +66,8 @@ module CookbookRelease
 
       def define_tasks(namespaced)
 
-        desc "Prepare cookbook release and push tag to git"
-        task "release!" do
+        desc 'Prepare cookbook release and push tag to git'
+        task 'release!' do
           opts = {
             no_prompt: ENV['NO_PROMPT'],
             category: ENV['COOKBOOK_CATEGORY'],
@@ -54,22 +76,22 @@ module CookbookRelease
           Release.new(git, opts).release!
         end
 
-        desc "Suggest new release version"
-        task "release:suggest_version" do
+        desc 'Suggest new release version'
+        task 'release:suggest_version' do
           git = GitUtilities.new
           release = Release.new(git)
           release.display_suggested_version(*release.new_version)
         end
 
-        desc "Display last released version"
-        task "release:version" do
+        desc 'Display last released version'
+        task 'release:version' do
           git = GitUtilities.new
           release = Release.new(git)
           puts release.last_release
         end
 
-        desc "Display changelog since last release"
-        task "release:changelog" do
+        desc 'Display changelog since last release'
+        task 'release:changelog' do
           git = GitUtilities.new
           release = Release.new(git)
           release.display_changelog(release.new_version.first)

--- a/lib/cookbook-release/changelog.rb
+++ b/lib/cookbook-release/changelog.rb
@@ -7,7 +7,6 @@ module CookbookRelease
       short_sha: true
     }
 
-    NO_RISKY = 'No risky/breaking commits.'
     RISKY = 'Risky/Breaking (details below):'
     FULL = 'Full changelog:'
     DETAILS = 'Details of risky commits:'
@@ -23,11 +22,8 @@ module CookbookRelease
 
     def raw_priority
       risky_commits = changelog.select { |c| c.risky? || c.major? }
-      result = if risky_commits.empty?
-                 "#{NO_RISKY}\n\n"
-               else
-                 "#{RISKY}\n" << risky_commits.map(&:to_s_oneline).join("\n") << "\n\n"
-               end
+      result = []
+      result << "#{RISKY}\n" << risky_commits.map(&:to_s_oneline).join("\n") << "\n" if risky_commits.any?
       result << "#{FULL}\n"
       result << changelog.map(&:to_s_oneline).join("\n")
     end
@@ -52,20 +48,16 @@ module CookbookRelease
     end
 
     def html_priority
-      result = []
       risky_commits = changelog.select { |c| c.risky? || c.major? }
+      result = []
       result << <<-EOH
 <html>
   <body>
       EOH
-      result << if risky_commits.empty?
-                  "    <p>#{NO_RISKY}</p>\n"
-                else
-                  "    <p>#{RISKY}</p>\n" << risky_commits.map { |c| c.to_s_html(false) }.map {|c| "    <p>#{c}</p>"}.join("\n")
-                end
+      result << "    <p>#{RISKY}</p>\n" << risky_commits.map { |c| c.to_s_html(false) }.map {|c| "    <p>#{c}</p>"}.join("\n") if risky_commits.any?
       result << "    <p>#{FULL}</p>\n"
       result << changelog.map { |c| c.to_s_html(false) }.map { |c| "    <p>#{c}</p>" }.join("\n")
-      unless risky_commits.empty?
+      if risky_commits.any?
         result << "\n<p>#{DETAILS}</p>\n"
         result << risky_commits.map { |c| c.to_s_html(true) }.map { |c| "    <p>#{c}</p>" }.join("\n")
       end
@@ -87,15 +79,12 @@ module CookbookRelease
 
     def markdown_priority
       risky_commits = changelog.select { |c| c.risky? || c.major? }
-      result = if risky_commits.empty?
-                 "*#{NO_RISKY}*\n\n"
-               else
-                 "*#{RISKY}*\n" << risky_commits.map { |c| c.to_s_markdown(false) }.join("\n") << "\n\n"
-               end
+      result = []
+      result << "*#{RISKY}*\n" << risky_commits.map { |c| c.to_s_markdown(false) }.join("\n") << "\n" if risky_commits.any?
       result << "*#{FULL}*\n"
       result << changelog.map { |c| c.to_s_markdown(false) }.join("\n")
-      unless risky_commits.empty?
-        result << "\n\n#{DETAILS}\n"
+      if risky_commits.any?
+        result << "\n#{DETAILS}\n"
         result << risky_commits.map { |c| c.to_s_markdown(true) }.join("\n")
       end
       result

--- a/lib/cookbook-release/changelog.rb
+++ b/lib/cookbook-release/changelog.rb
@@ -7,6 +7,11 @@ module CookbookRelease
       short_sha: true
     }
 
+    NO_RISKY = 'No risky/breaking commits.'
+    RISKY = 'Risky/Breaking (details below):'
+    FULL = 'Full changelog:'
+    DETAILS = 'Details of risky commits:'
+
     def initialize(git, opts = {})
       @git = git
       @opts = DEFAULT_OPTS.merge(opts)
@@ -14,6 +19,17 @@ module CookbookRelease
 
     def raw
       changelog.map(&:to_s_oneline)
+    end
+
+    def raw_priority
+      risky_commits = changelog.select { |c| c.risky? || c.major? }
+      result = if risky_commits.empty?
+                 "#{NO_RISKY}\n\n"
+               else
+                 "#{RISKY}\n" << risky_commits.map(&:to_s_oneline).join("\n") << "\n\n"
+               end
+      result << "#{FULL}\n"
+      result << changelog.map(&:to_s_oneline).join("\n")
     end
 
     def html
@@ -35,6 +51,31 @@ module CookbookRelease
       result.join("\n")
     end
 
+    def html_priority
+      result = []
+      risky_commits = changelog.select { |c| c.risky? || c.major? }
+      result << <<-EOH
+<html>
+  <body>
+      EOH
+      result << if risky_commits.empty?
+                  "    <p>#{NO_RISKY}</p>\n"
+                else
+                  "    <p>#{RISKY}</p>\n" << risky_commits.map { |c| c.to_s_html(false) }.map {|c| "    <p>#{c}</p>"}.join("\n")
+                end
+      result << "    <p>#{FULL}</p>\n"
+      result << changelog.map { |c| c.to_s_html(false) }.map { |c| "    <p>#{c}</p>" }.join("\n")
+      unless risky_commits.empty?
+        result << "\n<p>#{DETAILS}</p>\n"
+        result << risky_commits.map { |c| c.to_s_html(true) }.map { |c| "    <p>#{c}</p>" }.join("\n")
+      end
+      result <<  <<-EOH
+  </body>
+</html>
+      EOH
+      result.join("\n")
+    end
+
     def markdown
       changelog.map do |c|
         full_body ||= @opts[:expand_major] && c.major?
@@ -42,6 +83,22 @@ module CookbookRelease
         full_body ||= @opts[:expand_commit] && (c[:subject] =~ @opts[:expand_commit] || c[:body] =~ @opts[:expand_commit])
         c.to_s_markdown(full_body)
       end.join("\n")
+    end
+
+    def markdown_priority
+      risky_commits = changelog.select { |c| c.risky? || c.major? }
+      result = if risky_commits.empty?
+                 "*#{NO_RISKY}*\n\n"
+               else
+                 "*#{RISKY}*\n" << risky_commits.map { |c| c.to_s_markdown(false) }.join("\n") << "\n\n"
+               end
+      result << "*#{FULL}*\n"
+      result << changelog.map { |c| c.to_s_markdown(false) }.join("\n")
+      unless risky_commits.empty?
+        result << "\n\n#{DETAILS}\n"
+        result << risky_commits.map { |c| c.to_s_markdown(true) }.join("\n")
+      end
+      result
     end
 
     private


### PR DESCRIPTION
Gives priority to risky/breaking commits and puts them on top of the output. Shows a full changelog below the riskies without details and a detailed changelog for riskies below everything.