### PR TITLE
Allow silent fail

### DIFF
--- a/lib/cookbook-release/release.rb
+++ b/lib/cookbook-release/release.rb
@@ -86,7 +86,13 @@ module CookbookRelease
     end
 
     def release!
-      new_version = prepare_release
+
+      new_version = begin
+                      prepare_release
+                    rescue ExistingRelease
+                      raise unless ENV['COOKBOOK_RELEASE_SILENT_FAIL']
+                      exit 0
+                    end
       begin
         git.tag(new_version)
         display_changelog(new_version)


### PR DESCRIPTION
This will allow to relaunch 'rake release!' without failure when needed

Change-Id: Ib767c805e3e6cdd04c068626c6a5e416d81bcf2e