### PR TITLE
Add changelog directory parameter option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
   - 2.4.0
 before_install:
-  - rvm @global do gem uninstall bundler -a -x
   - rvm @global do gem install bundler -v 1.15.4
 deploy:
   provider: rubygems

--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ require 'cookbook-release'
 CookbookRelease::Rake::RepoTask.new
 ```
 
-will allow to create tasks to generate html changelog between HEAD and master branch. It aims to make some changes more visible such as [Risky] tag (or any tag used for major changes).
+will allow to create tasks to generate html changelog between HEAD and master branch. It aims to make some changes more visible such as [Risky] tag (or any tag used for major changes). You may add a `sub_dir` parameter to restrict the scope of the changes to a sub-directory of the git root.

--- a/cookbook-release.gemspec
+++ b/cookbook-release.gemspec
@@ -6,7 +6,7 @@ require 'English'
 
 Gem::Specification.new do |spec|
   spec.name          = 'cookbook-release'
-  spec.version       = '1.4.0'
+  spec.version       = '1.4.1'
   spec.authors       = ['Grégoire Seux']
   spec.email         = 'g.seux@criteo.com'
   spec.summary       = 'Provide primitives (and rake tasks) to release a cookbook'

--- a/lib/cookbook-release.rb
+++ b/lib/cookbook-release.rb
@@ -13,20 +13,21 @@ module CookbookRelease
     class RepoTask < ::Rake::TaskLib
       def initialize(opts = {}, &html_block)
         desc 'Display raw changelog between branches'
-        task 'changelog:raw' do
-          git = GitUtilities.new
+        task 'changelog:raw', [:sub_dir] do |_, args|
+          git = GitUtilities.new('sub_dir': args['sub_dir'])
           puts Changelog.new(git, opts).raw
         end
 
         desc 'Display raw changelog between branches with risky commits on top'
-        task 'changelog:raw_priority' do
-          git = GitUtilities.new
+        task 'changelog:raw_priority', [:sub_dir] do |_, args|
+          git = GitUtilities.new(args)
+          git = GitUtilities.new('sub_dir': args['sub_dir'])
           puts Changelog.new(git, opts).raw_priority
         end
 
         desc 'Display html changelog between branches'
-        task 'changelog:html' do
-          git = GitUtilities.new
+        task 'changelog:html', [:sub_dir] do |_, args|
+          git = GitUtilities.new('sub_dir': args['sub_dir'])
           html = Changelog.new(git, opts).html
           if block_given?
             html = html_block.call(html)
@@ -35,8 +36,8 @@ module CookbookRelease
         end
 
         desc 'Display html changelog between branches with risky commits on top'
-        task 'changelog:html_priority' do
-          git = GitUtilities.new
+        task 'changelog:html_priority', [:sub_dir] do |_, args|
+          git = GitUtilities.new('sub_dir': args['sub_dir'])
           html = Changelog.new(git, opts).html_priority
           if block_given?
             html = html_block.call(html)
@@ -45,14 +46,14 @@ module CookbookRelease
         end
 
         desc 'Display markdown changelog between branches'
-        task 'changelog:markdown' do
-          git = GitUtilities.new
+        task 'changelog:markdown', [:sub_dir] do |_, args|
+          git = GitUtilities.new('sub_dir': args['sub_dir'])
           puts Changelog.new(git, opts).markdown
         end
 
         desc 'Display markdown changelog between branches with risky commits on top'
-        task 'changelog:markdown_priority' do
-          git = GitUtilities.new
+        task 'changelog:markdown_priority', [:sub_dir] do |_, args|
+          git = GitUtilities.new('sub_dir': args['sub_dir'])
           puts Changelog.new(git, opts).markdown_priority
         end
       end

--- a/lib/cookbook-release/git-utilities.rb
+++ b/lib/cookbook-release/git-utilities.rb
@@ -12,6 +12,7 @@ module CookbookRelease
     def initialize(options={})
       @tag_prefix = options[:tag_prefix] || ''
       cwd = options[:cwd] || Dir.pwd
+      @sub_dir = options[:sub_dir] # if nil takes the cwd
       @shellout_opts = {
         cwd: cwd
       }
@@ -63,7 +64,7 @@ module CookbookRelease
     end
 
     def compute_changelog(since, short_sha = true)
-      @g.log(500).between(since, 'HEAD').map do |commit|
+      @g.log(500).object(@sub_dir).between(since, 'HEAD').map do |commit|
         message = commit.message.lines.map(&:chomp).compact.delete_if(&:empty?)
         Commit.new(
           author: commit.author.name,

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -123,10 +123,29 @@ git tag 12.34.56
         cmd.run_command
         cmd.error!
       end
-
       changelog = git.compute_changelog('1.0.0')
       expect(changelog.size).to eq(3)
       expect(changelog.map {|c| c[:subject]}).to contain_exactly('A commit', 'Another commit', 'A third one')
+    end
+
+    it 'shows only sub_dir commits' do
+      cmds = <<-EOH
+      git commit --allow-empty -m "subject" -m "body" -m "line2"
+      git commit --allow-empty -m "without body"
+      mkdir -p subbie
+      echo "hello" > subbie/there
+      git add subbie/there
+      git commit -m "hello there"
+      EOH
+      sub_git = CookbookRelease::GitUtilities.new(sub_dir: 'subbie')
+      cmds.split("\n").each do |cmd|
+        cmd = Mixlib::ShellOut.new(cmd)
+        cmd.run_command
+        cmd.error!
+      end
+
+      changelog = sub_git.compute_changelog('1.0.0')
+      expect(changelog.size).to eq(1)
     end
 
     it 'parse correctly commits' do


### PR DESCRIPTION
Currently the changelog takes the root of the git directory and looks
at all changes, regardless of the level. This patch takes the first
parameter and uses that for the `git log` command, if present. If
missing, it behaves as before