### PR TITLE
Properly un-escape emojis

### DIFF
--- a/cookbook-release.gemspec
+++ b/cookbook-release.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mixlib-shellout'
   spec.add_dependency 'chef', '>= 12.18.31'
   spec.add_dependency 'git-ng' # see https://github.com/schacon/ruby-git/issues/307
+  spec.add_dependency 'unicode-emoji'
 
 
   spec.add_development_dependency 'rspec'

--- a/lib/cookbook-release/commit.rb
+++ b/lib/cookbook-release/commit.rb
@@ -1,3 +1,6 @@
+require 'forwardable'
+require 'unicode/emoji'
+
 module CookbookRelease
   class Commit
     extend Forwardable
@@ -79,9 +82,18 @@ module CookbookRelease
       else
         result << "_#{self[:author]} <#{self[:email]}>_"
       end
-      result << " `#{self[:subject]}`"
+      result << ' '
+      result << backtick_string(self[:subject])
       result << "\n```\n#{strip_change_id(self[:body])}```" if full && self[:body]
       result
+    end
+
+    def backtick_string(input)
+      s = input.gsub(/( )?(#{Unicode::Emoji::REGEX})( )?/, '` \2 `')
+               .gsub(/( )?``( )?/, '')
+      s += '`' unless s =~ /`$/
+      s = '`' + s unless s =~ /^`/
+      s
     end
 
     private

--- a/spec/commit_spec.rb
+++ b/spec/commit_spec.rb
@@ -23,4 +23,16 @@ describe CookbookRelease::Commit do
       expect(minor_change)   .not_to be_patch
     end
   end
+
+  describe '.to_s_markdown' do
+    it 'surrounds subject with backticks' do
+      commit = CookbookRelease::Commit.new(subject: 'This is a fix', hash: 'abcdef', author: 'Linus', email: 'linus@linux.org')
+      expect(commit.to_s_markdown(false)).to match(/`#{commit[:subject]}`/)
+    end
+
+    it 'properly handle emojis' do
+      commit = CookbookRelease::Commit.new(subject: 'This is a fix 🔧 and I love 🪐🚀', hash: 'abcdef', author: 'Linus', email: 'linus@linux.org')
+      expect(commit.to_s_markdown(false)).to match(/`This is a fix` 🔧 `and I love` 🪐🚀/)
+    end
+  end
 end

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -150,8 +150,8 @@ git tag 12.34.56
 
     it 'parse correctly commits' do
       cmds = <<-EOH
-      git commit --allow-empty -m "subject" -m "body" -m "line2"
-      git commit --allow-empty -m "without body"
+      git commit --allow-empty --no-verify -m "subject" -m "body" -m "line2"
+      git commit --allow-empty --no-verify -m "without body"
       EOH
       cmds.split("\n").each do |cmd|
         cmd = Mixlib::ShellOut.new(cmd)


### PR DESCRIPTION
This patch provide a markdown message that does not escape emojis.
It makes pasting such messages in slack (for instance) more readable
(which is the goal of providing such changelog)

Emojis in commits have become more present so it's natural to start
supporting them.