### PR TITLE
Add support for multiple cookbooks in a single repository

### DIFF
--- a/lib/cookbook-release/git-utilities.rb
+++ b/lib/cookbook-release/git-utilities.rb
@@ -43,11 +43,12 @@ module CookbookRelease
     def _compute_last_release
       tag = Mixlib::ShellOut.new([
         'git describe',
+        "--abbrev=0",
         "--tags",
         "--match \"#{@tag_prefix}[0-9]*\.[0-9]*\.[0-9]*\""
       ].join(" "), @shellout_opts)
       tag.run_command
-      tag.stdout.split('-').first
+      tag.stdout.chomp
     end
 
     def has_any_release?

--- a/lib/cookbook-release/git-utilities.rb
+++ b/lib/cookbook-release/git-utilities.rb
@@ -48,7 +48,7 @@ module CookbookRelease
         "--match \"#{@tag_prefix}[0-9]*\.[0-9]*\.[0-9]*\""
       ].join(" "), @shellout_opts)
       tag.run_command
-      tag.stdout.chomp
+      tag.stdout.sub(/^#{@tag_prefix}/, '').chomp
     end
 
     def has_any_release?
@@ -65,7 +65,8 @@ module CookbookRelease
     end
 
     def compute_changelog(since, short_sha = true)
-      @g.log(500).object(@sub_dir).between(since, 'HEAD').map do |commit|
+      ref = "#{@tag_prefix}#{since}"
+      @g.log(500).object(@sub_dir).between(ref, 'HEAD').map do |commit|
         message = commit.message.lines.map(&:chomp).compact.delete_if(&:empty?)
         Commit.new(
           author: commit.author.name,

--- a/lib/cookbook-release/git-utilities.rb
+++ b/lib/cookbook-release/git-utilities.rb
@@ -23,6 +23,12 @@ module CookbookRelease
       File.directory?(::File.join(dir, '.git'))
     end
 
+    def self.find_root(dir = Dir.pwd)
+      cmd = Mixlib::ShellOut.new("git rev-parse --show-toplevel", cwd: dir)
+      cmd.run_command
+      cmd.error? ? nil : cmd.stdout.chomp
+    end
+
     def reset_command(new_version)
       remote = choose_remote
       "git tag -d #{new_version} ; git push #{remote} :#{new_version}"

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -44,6 +44,12 @@ describe CookbookRelease::GitUtilities do
       expect(CookbookRelease::GitUtilities.git?(tmp)).to be(true)
       FileUtils.rm_rf(tmp)
     end
+
+    it 'finds repo\'s root from subdir' do
+      subdir = 'cookbooks/mycookbook'
+      FileUtils.mkdir_p(subdir)
+      expect(CookbookRelease::GitUtilities.find_root(subdir)).to eq(Dir.pwd)
+    end
   end
 
   describe '.clean_index(?|!)' do


### PR DESCRIPTION
In order for this lib to work in a monorepo setup, we need to support cookbooks in sub-directories and per-cookbook tag names.
With these changes we are able to tag a commit with a `cookbook-x.y.z` with level depending on changes in cookbook's directory only.
For instance, a `major` change to `cookbooks/cookbook_a` directory would give a `cookbook_a-2.0.0` tag.