### PR TITLE
Add constraint on Chef to not support version >= 17

### DIFF
--- a/cookbook-release.gemspec
+++ b/cookbook-release.gemspec
@@ -6,7 +6,7 @@ require 'English'
 
 Gem::Specification.new do |spec|
   spec.name          = 'cookbook-release'
-  spec.version       = '1.5.1'
+  spec.version       = '1.6.0'
   spec.authors       = ['Grégoire Seux']
   spec.email         = 'g.seux@criteo.com'
   spec.summary       = 'Provide primitives (and rake tasks) to release a cookbook'
@@ -22,7 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'semantic'
   spec.add_dependency 'highline'
   spec.add_dependency 'mixlib-shellout'
-  spec.add_dependency 'chef', '>= 12.18.31'
+  # TODO: support Chef 17 and leverage knife gem at some point
+  spec.add_dependency 'chef', '>= 12.18.31', '< 17.0' # knife code has been moved to dedicated gem starting with Chef 17
   spec.add_dependency 'git-ng' # see https://github.com/schacon/ruby-git/issues/307
   spec.add_dependency 'unicode-emoji'
 


### PR DESCRIPTION
With Chef 17, the knife code has been extracted to a dedicated gem.
=> This means that to be compatible with Chef 17 we should leverage the knife gem which only supports Chef 17.

As for now we want to be compatible with older Chef version we can't do that so easily.

The idea is to create a 1.6 branch which support Chef until version 17, and once stable [1], release a 2.0 version of cookbook release with only Chef 17 support.

[1] otherwise we'll have to backport fixes on 1.6 branch