### PR TITLE
Fix git root directory discovery

### DIFF
--- a/lib/cookbook-release/git-utilities.rb
+++ b/lib/cookbook-release/git-utilities.rb
@@ -24,6 +24,9 @@ module CookbookRelease
     end
 
     def self.find_root(dir = Dir.pwd)
+      # Do not consider given dir as part of the git repo if not in git hierarchy or dir is not tracked
+      return if ::Mixlib::ShellOut.new('git ls-files --error-unmatch .', cwd: dir).run_command.error?
+
       cmd = Mixlib::ShellOut.new("git rev-parse --show-toplevel", cwd: dir)
       cmd.run_command
       cmd.error? ? nil : cmd.stdout.chomp

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -45,9 +45,18 @@ describe CookbookRelease::GitUtilities do
       FileUtils.rm_rf(tmp)
     end
 
-    it 'finds repo\'s root from subdir' do
+    it 'do not finds repo\'s root from untracked subdir' do
       subdir = 'cookbooks/mycookbook'
       FileUtils.mkdir_p(subdir)
+      expect(CookbookRelease::GitUtilities.find_root(subdir)).to be nil
+    end
+
+    it 'finds repo\'s root from tracked subdir' do
+      subdir = 'cookbooks/mycookbook'
+      tracked_file = ::File.join(subdir, 'tracked_file')
+      FileUtils.mkdir_p(subdir)
+      FileUtils.touch(tracked_file)
+      ::Mixlib::ShellOut.new("git add '#{tracked_file}'").run_command
       expect(CookbookRelease::GitUtilities.find_root(subdir)).to eq(Dir.pwd)
     end
   end


### PR DESCRIPTION
Initial implementation could produce invalid result when the code is evaluated in a git directory which is not related with the cookbook.

For instance when berkshelf fetches cookbooks from git source it will checkout the code in a configured berkshelf_path directory and evaluate the metadata.rb of the cookbook.
If the configured berkshelf_path is inside a git directory, this will be considered as the "git root dir" of the cookbook and will mess up with the version computation.

This commit fixes the GitUtilities.find_root logic by quickly checking whether the given directory is tracked by git.
If the dir is not tracked or the command used to determine the tracking status just fail, it means it is not part of the parent git repository.