### PR TITLE
Update supermarket push for mono-repo layout

### DIFF
--- a/lib/cookbook-release/git-utilities.rb
+++ b/lib/cookbook-release/git-utilities.rb
@@ -8,6 +8,7 @@ module CookbookRelease
   class GitUtilities
 
     attr_accessor :no_prompt
+    attr_reader :sub_dir
 
     def initialize(options={})
       @tag_prefix = options[:tag_prefix] || ''

--- a/lib/cookbook-release/release.rb
+++ b/lib/cookbook-release/release.rb
@@ -108,7 +108,7 @@ module CookbookRelease
         exit 1 unless agreed
         git.push_tag(new_version)
         supermarket = Supermarket.new
-        supermarket.publish_ck(@category)
+        supermarket.publish_ck(@category, git.sub_dir)
       rescue
         puts HighLine.color("Release aborted, you have to reset to previous state manually", :red)
         puts ":use with care: #{git.reset_command(new_version)}"

--- a/lib/cookbook-release/supermarket.rb
+++ b/lib/cookbook-release/supermarket.rb
@@ -8,7 +8,7 @@ require 'json'
 module CookbookRelease
   class Supermarket
 
-    # This code is adapted from "knife cookbook share" and travis dpl provider 
+    # This code is adapted from "knife cookbook share" and travis dpl provider
     # for supermarket.
 
     def initialize(opts={})
@@ -20,11 +20,11 @@ module CookbookRelease
 
     include ::Chef::Mixin::ShellOut
 
-    def publish_ck(category)
-      ck = ::Chef::Cookbook::CookbookVersionLoader.new('.')
+    def publish_ck(category, path = nil)
+      ck = ::Chef::Cookbook::CookbookVersionLoader.new(path || '.')
       ck.load!
       cookbook = ck.cookbook_version
-      # we have to provide a rest option otherwise it will try to load a 
+      # we have to provide a rest option otherwise it will try to load a
       # client.pem key
       ::Chef::CookbookUploader.new(cookbook, rest: 'fake_rest').validate_cookbooks
 


### PR DESCRIPTION
Cookbook path was hardcoded to '.'; allow passing it as parameter to
 #publish_ck, and use git sub_dir property to fill it.