### PR TITLE
use upstream git library instead of outdated fork

### DIFF
--- a/cookbook-release.gemspec
+++ b/cookbook-release.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mixlib-shellout'
   # TODO: support Chef 17 and leverage knife gem at some point
   spec.add_dependency 'chef', '>= 12.18.31', '< 17.0' # knife code has been moved to dedicated gem starting with Chef 17
-  spec.add_dependency 'git-ng' # see https://github.com/schacon/ruby-git/issues/307
+  spec.add_dependency 'git'
   spec.add_dependency 'unicode-emoji'
 
 


### PR DESCRIPTION
git-ng fork has not been updated for 7 years, and requiring it here creates some conflicts where we expect to have the 'git' gem used and we instead get the 'git-ng' one.

Issue with utf-8 https://github.com/kamaradclimber/ruby-git/commit/5856b704007db12fb64f204ec42491992934f2f4 should be fine with upstream git updated code https://github.com/ruby-git/ruby-git/blob/dce68167840d2027832f321a9e0945b81e3b4cf7/lib/git/lib.rb#L1153

If not, worst case scenario is we do not have emojis in the commit messages...